### PR TITLE
Update IsSigned to use signtool.exe

### DIFF
--- a/NAnt.Extensions/Functions/Microsoft/Signing.cs
+++ b/NAnt.Extensions/Functions/Microsoft/Signing.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 The MIT License (MIT)
 
 Copyright (c) 2013-2014 Dave Tuchlinsky, Stephen Tunney, Canada (stephen.tunney@gmail.com)
@@ -21,9 +21,13 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 using System;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
+using System.Text;
 using NAnt.Core;
 using NAnt.Core.Attributes;
+using NAnt.Extensions.Tasks.Microsoft;
 
 namespace NAnt.Extensions.Functions.Microsoft
 {
@@ -49,12 +53,40 @@ namespace NAnt.Extensions.Functions.Microsoft
             if (!File.Exists(filePath)) throw new FileNotFoundException(filePath);
             try
             {
-                System.Security.Cryptography.X509Certificates.X509Certificate certificate = new System.Security.Cryptography.X509Certificates.X509Certificate(filePath);
-                // An exception would be thrown if the file was not signed
-                return true;
+                Process myProcess = new Process();
+                try
+                {
+                    StringBuilder args = new StringBuilder(@"verify /pa ");
+                    args.Append(@"/v ");
+                    args.Append(filePath);
+
+                    myProcess.StartInfo.FileName = SignTask.DefaultSignToolPath + @"\signtool.exe";
+                    myProcess.StartInfo.Arguments = args.ToString();
+                    myProcess.StartInfo.UseShellExecute = false;
+                    myProcess.StartInfo.RedirectStandardOutput = true;
+
+                    int exitCode = 1;
+                    myProcess.Start();
+                    myProcess.WaitForExit();
+                    exitCode = myProcess.ExitCode;
+                    myProcess.Close();
+
+                    // Check for errors
+                    if (exitCode == 2)
+                        throw new BuildException("Failed Execution has completed with warnings.");
+                    else if (exitCode != 0)
+                        throw new BuildException("Failed to sign. Error " + exitCode);
+                }
+                catch (Win32Exception e)
+                {
+                    throw new BuildException("Unable to find signtool.exe in " + SignTask.DefaultSignToolPath, e);
+                }
             }
-            catch (Exception e) { }
-            return false;
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
Fixed: The IsSigned function could not check corretly that the binary is signed or not.