### PR TITLE
Added exportFilesBinariesIcons attribute

### DIFF
--- a/NAnt.Extensions/Tasks/WiX/Melt.cs
+++ b/NAnt.Extensions/Tasks/WiX/Melt.cs
@@ -161,8 +161,8 @@ namespace NAnt.Extensions.Tasks.WiX
                 if (!string.IsNullOrEmpty(ExtractedBinariesPath))
                 {
                     arguments += string.Format(@" -x ""{0}""", ExtractedBinariesPath);
-                    if (this.ExportFilesBinariesIcons)
-                        empty += string.Format(" {0}", (object)"-xn");
+                    if (ExportFilesBinariesIcons)
+                        arguments += " -xn";
                 }
 
                 if (!string.IsNullOrEmpty(ExtensionClassAssemblyFullyQualifiedClassName))

--- a/NAnt.Extensions/Tasks/WiX/Melt.cs
+++ b/NAnt.Extensions/Tasks/WiX/Melt.cs
@@ -102,6 +102,10 @@ namespace NAnt.Extensions.Tasks.WiX
         [StringValidator(AllowEmpty = false)]
         public virtual string ExportBinariesPath { get; set; }
 
+        [TaskAttribute("exportFilesBinariesIcons", Required = false)]
+        [BooleanValidator]
+        public virtual bool ExportFilesBinariesIcons { get; set; }
+
         #endregion Public Instance Properties
 
         #region Override implementation of Task
@@ -157,6 +161,8 @@ namespace NAnt.Extensions.Tasks.WiX
                 if (!string.IsNullOrEmpty(ExtractedBinariesPath))
                 {
                     arguments += string.Format(@" -x ""{0}""", ExtractedBinariesPath);
+                    if (this.ExportFilesBinariesIcons)
+                        empty += string.Format(" {0}", (object)"-xn");
                 }
 
                 if (!string.IsNullOrEmpty(ExtensionClassAssemblyFullyQualifiedClassName))


### PR DESCRIPTION
Added `exportFilesBinariesIcons` attribute to `wix_melt` element to support the `-xn` option for melt.exe.